### PR TITLE
Potential fix for code scanning alert no. 2: Reflected server-side cross-site scripting

### DIFF
--- a/heltour/tournament/android_app.py
+++ b/heltour/tournament/android_app.py
@@ -7,6 +7,7 @@ import logging
 from pyfcm import FCMNotification
 from heltour.tournament.models import FcmSub
 import requests
+import html
 
 logger = logging.getLogger(__name__)
 
@@ -36,7 +37,7 @@ def slack_event(request):
     request_type = args.get('type')
 
     if request_type == 'url_verification':
-        return HttpResponse(args.get('challenge'))
+        return HttpResponse(html.escape(args.get('challenge')))
 
     if request_type == 'event_callback':
         event = args.get('event')


### PR DESCRIPTION
Potential fix for [https://github.com/securityuniverse/heltour/security/code-scanning/2](https://github.com/securityuniverse/heltour/security/code-scanning/2)

To fix the problem, we need to escape the user-provided value before including it in the HTTP response. In Python, we can use the `html.escape()` function from the `html` module to escape any special characters in the user input, ensuring that it is safe to include in the response.

The best way to fix this issue without changing existing functionality is to import the `html` module and use the `html.escape()` function to sanitize the `args.get('challenge')` value before returning it in the `HttpResponse`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
